### PR TITLE
use https git url in clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to explain the command.
 Clone the repository:
 
 ```
-git clone git@github.com:stefanheule/zsh-llm-suggestions.git ~/zsh/zsh-llm-suggestions
+git clone https://github.com/stefanheule/zsh-llm-suggestions.git ~/zsh/zsh-llm-suggestions
 ```
 
 Source the script and configure the hotkey in `.zshrc`:


### PR DESCRIPTION
When using the original command (`git clone git@github.com:stefanheule/zsh-llm-suggestions.git ~/zsh/zsh-llm-suggestions`) in the readme I got this error:
```
Cloning into '/Users/goleary/zsh/zsh-llm-suggestions'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
Swapping to the github repo https url resolved it for me.